### PR TITLE
cursor.map returns Array<T> not void

### DIFF
--- a/definitions/meteor.d.ts
+++ b/definitions/meteor.d.ts
@@ -576,7 +576,7 @@ declare module Mongo {
 		count(): number;
 		fetch(): Array<T>;
 		forEach(callback: <T>(doc: T, index: number, cursor: Mongo.Cursor<T>) => void, thisArg?: any): void;
-		map(callback: <T>(doc: T, index: number, cursor: Mongo.Cursor<T>) => void, thisArg?: any): void;
+		map(callback: <T>(doc: T, index: number, cursor: Mongo.Cursor<T>) => void, thisArg?: any): Array<T>;
 		observe(callbacks: Object): Meteor.LiveQueryHandle;
 		observeChanges(callbacks: Object): Meteor.LiveQueryHandle;
 	}

--- a/scripts/generate-definition-files.js
+++ b/scripts/generate-definition-files.js
@@ -179,7 +179,7 @@ var propertyAndReturnTypeMappings = {
     'Mongo.Cursor#count': 'number',
     'Mongo.Cursor#fetch': 'Array<T>',
     'Mongo.Cursor#forEach': 'void',
-    'Mongo.Cursor#map': 'void',
+    'Mongo.Cursor#map': 'Array<T>',
     'Mongo.Cursor#observe': 'Meteor.LiveQueryHandle',
     'Mongo.Cursor#observeChanges': 'Meteor.LiveQueryHandle',
     'Plugin.registerSourceHandler': 'void',

--- a/tinytest-definition-tests/meteor-tests.ts
+++ b/tinytest-definition-tests/meteor-tests.ts
@@ -297,6 +297,8 @@ topPosts.forEach(function (post) {
     count += 1;
 });
 
+topPosts.map((post) => post.score).length;
+
 /**
  * From Collections, cursor.observeChanges section
  */


### PR DESCRIPTION
As stated in [meteor docs](http://docs.meteor.com/#/full/map) the `cursor.map` method does not return `void` but `Array<T>`.