### PR TITLE
Meteor.Error.error is `string`, not `number`

### DIFF
--- a/definitions/meteor.d.ts
+++ b/definitions/meteor.d.ts
@@ -126,7 +126,7 @@ declare module Meteor {
     }
 
     interface Error {
-        error: number;
+        error: string;
         reason?: string;
         details?: string;
     }

--- a/lib/meteor-manually-maintained-definitions.d.ts
+++ b/lib/meteor-manually-maintained-definitions.d.ts
@@ -126,7 +126,7 @@ declare module Meteor {
     }
 
     interface Error {
-        error: number;
+        error: string;
         reason?: string;
         details?: string;
     }

--- a/script-definition-tests/meteor-tests.ts
+++ b/script-definition-tests/meteor-tests.ts
@@ -129,6 +129,22 @@ Meteor.methods({
 });
 
 /**
+ * From Methods, Meteor.Error section
+ */
+throw new Meteor.Error("logged-out",
+    "The user must be logged in to post a comment.");
+
+Meteor.call("methodName", function (error) {
+  if (error.error === "logged-out") {
+    Session.set("errorMessage", "Please log in to post a comment.");
+  }
+});
+var error = new Meteor.Error("logged-out", "The user must be logged in to post a comment.");
+console.log(error.error === "logged-out");
+console.log(error.reason === "The user must be logged in to post a comment.");
+console.log(error.details !== "");
+
+/**
  * From Methods, Meteor.call section
  */
 Meteor.call('foo', 1, 2, function (error, result) {} );


### PR DESCRIPTION
The [`Meteor.Error` constructor states](https://github.com/meteor-typescript/meteor-typescript-libs/blob/master/definitions/meteor.d.ts#L497) that `error` argument is `string`:

    declare module Meteor {
	interface ErrorStatic {
		new(error: string, reason?: string, details?: string): Error;
	}

but `Meteor.Error`'s field `error` is marked as `number`:

    interface Error {
        error: number;
        reason?: string;
        details?: string;
    }

[Meteor docs](https://docs.meteor.com/#/full/meteor_error) say that the constructor definition is correct, so to be consistent the interface should have `error:string`.
