### PR TITLE
Corrected return type of cursor#map

### DIFF
--- a/scripts/generate-definition-files.js
+++ b/scripts/generate-definition-files.js
@@ -183,7 +183,7 @@ var propertyAndReturnTypeMappings = {
     'Mongo.Cursor#count': 'number',
     'Mongo.Cursor#fetch': 'Array<T>',
     'Mongo.Cursor#forEach': 'void',
-    'Mongo.Cursor#map': 'Array<T>',
+    'Mongo.Cursor#map': 'Array<Any>',
     'Mongo.Cursor#observe': 'Meteor.LiveQueryHandle',
     'Mongo.Cursor#observeChanges': 'Meteor.LiveQueryHandle',
     'Plugin.registerSourceHandler': 'void',


### PR DESCRIPTION
The map method of the cursor object allow you to transform the document returned by Mongo into whatever you want.
Hence the return type of this function is Array<Any> and not Array<T>
