### PR TITLE
Get Mongo.Selector to accept Object literals

### DIFF
--- a/lib/meteor-manually-maintained-definitions.d.ts
+++ b/lib/meteor-manually-maintained-definitions.d.ts
@@ -133,7 +133,9 @@ declare module Meteor {
 }
 
 declare module Mongo {
-    interface Selector extends Object {}
+    interface Selector {
+      [key: string]:any;
+    } 
     interface Modifier {}
     interface SortSpecifier {}
     interface FieldSpecifier {


### PR DESCRIPTION
With foo a collection, 
when doing 
```ts
foo.find({_id: id})
```
typescript complains that Selector has no member "_id".
With this modification, it accepted every selector i throwed at him.