### PR TITLE
Update meteor.d.ts

### DIFF
--- a/definitions/meteor.d.ts
+++ b/definitions/meteor.d.ts
@@ -45,7 +45,7 @@ declare module Meteor {
         _id?:string;
         username?:string;
         emails?:Meteor.UserEmail[];
-        createdAt?: number;
+        createdAt?: Date;
         profile?: any;
         services?: any;
     }


### PR DESCRIPTION
Shouldn't Meteor.user.createdAt be typeof Date? The documentation prints proper dates (http://docs.meteor.com/#/full/meteor_users) and the default implementation of aldeed:simple-schema as well.